### PR TITLE
Fix letter order inside formspec, switch to core namespace

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -6,7 +6,7 @@ globals = {
 }
 
 read_globals = {
-	"minetest",
+	"core",
 	"vector",
 	"default",
 	table = {

--- a/Readme.md
+++ b/Readme.md
@@ -43,7 +43,7 @@ letters.register_letters("darkage",
 ```
 You will need to add letters as a dependency to your mod, or include the registrations is the code:
 ```lua
-if minetest.get_modpath("letters") then
+if core.get_modpath("letters") then
 	letters.register_letters("darkage", "marble", "darkage:marble", "Marble", "darkage_marble.png")
 	--ect ect...
 end

--- a/api.lua
+++ b/api.lua
@@ -1,5 +1,5 @@
-local lettersmod = minetest.get_current_modname()
-local letterspath = minetest.get_modpath(lettersmod)
+local lettersmod = core.get_current_modname()
+local letterspath = core.get_modpath(lettersmod)
 local letter_cutter = letters.letter_cutter
 
 letter_cutter.known_nodes = {}
@@ -8,7 +8,9 @@ letter_cutter.known_nodes = {}
 letter_cutter.names_upper = {}
 letter_cutter.names_lower = {}
 letter_cutter.names_digit = {}
-for _, tile in ipairs(minetest.get_dir_list(letterspath .. "/textures", false)) do
+local files = core.get_dir_list(letterspath .. "/textures", false)
+table.sort(files)
+for _, tile in ipairs(files) do
 	local char, group = tile:match("_([%d%u%l])(%l)_overlay")
 	if char and group then
 		if group == "d" then
@@ -53,7 +55,7 @@ function letters.register_letters(modname, subname, from_node, description, tile
 	basedef.legacy_wallmounted = false
 
 	-- Register a new node for each letter using the provided from_node as the material.
-	for _, tile in ipairs(minetest.get_dir_list(letterspath .. "/textures", false)) do
+	for _, tile in ipairs(core.get_dir_list(letterspath .. "/textures", false)) do
 		local char, group = tile:match("_([%d%u%l])(%l)_overlay")
 		if char and group then
 			local def = table.copy(basedef)
@@ -69,7 +71,7 @@ function letters.register_letters(modname, subname, from_node, description, tile
 			def.wield_image = def.inventory_image
 			def.tiles = {def.inventory_image}
 
-			minetest.register_node(":" ..modname..":"..subname.. "_letter_" ..char..group,def)
+			core.register_node(":" ..modname..":"..subname.. "_letter_" ..char..group,def)
 		end
 	end
 	letter_cutter.known_nodes[from_node] = {modname, subname}

--- a/api.lua
+++ b/api.lua
@@ -55,7 +55,7 @@ function letters.register_letters(modname, subname, from_node, description, tile
 	basedef.legacy_wallmounted = false
 
 	-- Register a new node for each letter using the provided from_node as the material.
-	for _, tile in ipairs(core.get_dir_list(letterspath .. "/textures", false)) do
+	for _, tile in ipairs(files) do
 		local char, group = tile:match("_([%d%u%l])(%l)_overlay")
 		if char and group then
 			local def = table.copy(basedef)

--- a/description.txt
+++ b/description.txt
@@ -1,1 +1,0 @@
-Adds a letter cutting tool with letter "signlike" nodes.

--- a/init.lua
+++ b/init.lua
@@ -2,11 +2,11 @@ letters = {
 	letter_cutter = {}
 }
 
-local MP = minetest.get_modpath(minetest.get_current_modname())
+local MP = core.get_modpath(core.get_current_modname())
 dofile(MP..'/api.lua')
 dofile(MP..'/itemlist.lua')
 
-if minetest.get_modpath("default") then
+if core.get_modpath("default") then
 	dofile(MP..'/letter_cutter.lua')
 end
 

--- a/itemlist.lua
+++ b/itemlist.lua
@@ -2,7 +2,7 @@
 To open the item list dialog, add a do_file :
 
 local show_item_list = dofile(
-	minetest.get_modpath(minetest.get_current_modname())..'/itemlist.lua')
+	core.get_modpath(core.get_current_modname())..'/itemlist.lua')
 
 ...
 
@@ -24,7 +24,7 @@ local style={
 	cols = 3,       -- Number of columns of items displayed
 }
 
-local modname = minetest.get_current_modname()
+local modname = core.get_current_modname()
 
 local contexts = {}
 
@@ -32,13 +32,13 @@ local function get_player_name(player)
 	if type(player) == 'string' then
 		return player
 	end
-	if minetest.is_player(player) then
+	if core.is_player(player) then
 		return player:get_player_name()
 	end
-	minetest.log('warning',	'['..modname..'] get_player_name could not identify player.')
+	core.log('warning',	'['..modname..'] get_player_name could not identify player.')
 end
 
-minetest.register_on_leaveplayer(function(player)
+core.register_on_leaveplayer(function(player)
 	local playername = get_player_name(player)
 	if playername then
 		contexts[playername] = nil
@@ -57,7 +57,7 @@ end
 
 -- Show node formspec functions
 local function show_node_formspec(playername, pos)
-	local meta = minetest.get_meta(pos)
+	local meta = core.get_meta(pos)
 
 	-- Decontextualize formspec
 	local fs = meta:get_string('formspec')
@@ -73,13 +73,13 @@ local function show_node_formspec(playername, pos)
 		s, e = fs:find('%${.*}')
 		if s and e then
 			fs = fs:sub(1, s-1)..
-				minetest.formspec_escape(meta:get_string(fs:sub(s+2,e-1)))..
+				core.formspec_escape(meta:get_string(fs:sub(s+2,e-1)))..
 				fs:sub(e+1)
 		end
 	until s == nil
 
 	-- Find node on_receive_fields
-	local ndef = minetest.registered_nodes[minetest.get_node(pos).name]
+	local ndef = core.registered_nodes[core.get_node(pos).name]
 
 	local context = get_context(playername)
 	context.node_pos = pos
@@ -89,10 +89,10 @@ local function show_node_formspec(playername, pos)
 	end
 
 	-- Show formspec
-	minetest.show_formspec(playername, modname..':context_formspec', fs)
+	core.show_formspec(playername, modname..':context_formspec', fs)
 end
 
-minetest.register_on_player_receive_fields(function(player, formname, fields)
+core.register_on_player_receive_fields(function(player, formname, fields)
 	if formname == modname..':context_formspec' then
 		local context = get_context(player)
 		if context == nil then
@@ -114,7 +114,7 @@ end
 local function item_list_prepare(item_list)
 	local list = {}
 	for _, name in ipairs(item_list) do
-		local ndef = minetest.registered_items[name]
+		local ndef = core.registered_items[name]
 		if ndef then
 			list[#list+1] = ndef
 		end
@@ -167,11 +167,11 @@ local function show_item_list_formspec(player)
 			end
 		end
 	end
-	minetest.show_formspec(
+	core.show_formspec(
 		context.playername, modname..':item_list', table.concat(parts))
 end
 
-minetest.register_on_player_receive_fields(function(player, formname, fields)
+core.register_on_player_receive_fields(function(player, formname, fields)
 	if formname ~= modname..':item_list' then
 		return
 	end
@@ -192,7 +192,7 @@ minetest.register_on_player_receive_fields(function(player, formname, fields)
 	if fields.quit == 'true' then
 		if context.node_pos then
 			-- Using after to avoid the "double close" bug
-			minetest.after(0, show_node_formspec, get_player_name(player),
+			core.after(0, show_node_formspec, get_player_name(player),
 				context.node_pos)
 		end
 	end

--- a/letter_cutter.lua
+++ b/letter_cutter.lua
@@ -318,7 +318,7 @@ function letter_cutter.on_receive_fields(pos, _formname, fields, sender)
 end
 
 core.register_node("letters:letter_cutter_lower",  {
-	description = "Lower Case Leter Cutter",
+	description = "Lower Case Letter Cutter",
 	drawtype = "nodebox",
 	node_box = {
 		type = "fixed",
@@ -376,7 +376,7 @@ core.register_craft({
 })
 
 core.register_node("letters:letter_cutter_upper",  {
-	description = "Upper Case Leter Cutter",
+	description = "Upper Case Letter Cutter",
 	drawtype = "nodebox",
 	node_box = {
 		type = "fixed",

--- a/letter_cutter.lua
+++ b/letter_cutter.lua
@@ -17,7 +17,7 @@ end
 
 -- Reset letter cutter to its empty state.
 function letter_cutter:reset(pos)
-	local meta = minetest.get_meta(pos)
+	local meta = core.get_meta(pos)
 	local inv  = meta:get_inventory()
 
 	inv:set_list("input",  {})
@@ -32,7 +32,7 @@ end
 
 -- Update letter cutter inventories with available material count.
 function letter_cutter:update_inventory(pos, amount)
-	local meta          = minetest.get_meta(pos)
+	local meta          = core.get_meta(pos)
 	local inv           = meta:get_inventory()
 
 	amount = meta:get_int("anz") + amount
@@ -89,7 +89,7 @@ function letter_cutter.allow_metadata_inventory_put(pos, listname, index, stack,
 		return 0
 	end
 
-	local meta = minetest.get_meta(pos)
+	local meta = core.get_meta(pos)
 	local inv  = meta:get_inventory()
 	local stackname = stack:get_name()
 	local count = stack:get_count()
@@ -138,7 +138,7 @@ end
 
 -- The name of the group of letters managed by this letter cutter.
 function letter_cutter.group_name(pos)
-	local node = minetest.get_node(pos)
+	local node = core.get_node(pos)
 	if node.name == "letters:letter_cutter_digit" then
 		return "Digit"
 	elseif node.name == "letters:letter_cutter_upper" then
@@ -150,7 +150,7 @@ end
 
 -- The group of letters managed by this letter cutter.
 function letter_cutter.group(pos)
-	local node = minetest.get_node(pos)
+	local node = core.get_node(pos)
 	if node.name == "letters:letter_cutter_digit" then
 		return letter_cutter.names_digit
 	elseif node.name == "letters:letter_cutter_upper" then
@@ -162,7 +162,7 @@ end
 
 -- Consume the input material and update inventories.
 function letter_cutter.remove_from_input(pos, origname, count)
-	local meta = minetest.get_meta(pos)
+	local meta = core.get_meta(pos)
 
 	local cutterinv = meta:get_inventory()
 
@@ -174,7 +174,7 @@ local gui_slots = "listcolors[#606060AA;#808080;#101010;#202020;#FFF]"
 
 -- Update formspec.
 local function update_cutter_formspec(pos)
-	local meta = minetest.get_meta(pos)
+	local meta = core.get_meta(pos)
 	meta:set_string("formspec", "size[11,9]" ..gui_slots..
 			"label[0,0;Input\nmaterial]" ..
 			"list[current_name;input;1.5,0;1,1;]" ..
@@ -183,14 +183,14 @@ local function update_cutter_formspec(pos)
 			"list[current_player;main;1.5,5;8,4;]" ..
 			"field[0.5,4.3;3,1;text;Enter text;${text}]" ..
 			"button[3.5,4;2,1;make_text;Make text]" ..
-			"label[5.5,4.2;" .. minetest.formspec_escape(meta:get_string("message")) .. "]")
+			"label[5.5,4.2;" .. core.formspec_escape(meta:get_string("message")) .. "]")
 end
 
 -- Create letter nodes from player-supplied text string.
 local function cut_from_text(pos, input_text, player)
 	local playername = player:get_player_name()
 
-	local meta = minetest.get_meta(pos)
+	local meta = core.get_meta(pos)
 
 	local cutterinv = meta:get_inventory()
 	local cutterinput = cutterinv:get_list("input")
@@ -209,7 +209,7 @@ local function cut_from_text(pos, input_text, player)
 	meta:set_string("text", input_text)
 
 	local totalcost = 0
-	local throwawayinv = minetest.create_detached_inventory("letter_cutter:throwaway", {}, playername)
+	local throwawayinv = core.create_detached_inventory("letter_cutter:throwaway", {}, playername)
 
 	throwawayinv:set_size("main", playerinv:get_size("main"))
 	throwawayinv:set_list("main", playerinv:get_list("main"))
@@ -234,7 +234,7 @@ local function cut_from_text(pos, input_text, player)
 			meta:set_string("message", "Not enough materials.")
 			update_cutter_formspec(pos)
 
-			minetest.remove_detached_inventory("letter_cutter:throwaway")
+			core.remove_detached_inventory("letter_cutter:throwaway")
 			return
 		end
 
@@ -242,7 +242,7 @@ local function cut_from_text(pos, input_text, player)
 			meta:set_string("message", "Not enough room.")
 			update_cutter_formspec(pos)
 
-			minetest.remove_detached_inventory("letter_cutter:throwaway")
+			core.remove_detached_inventory("letter_cutter:throwaway")
 			return
 		end
 
@@ -258,7 +258,7 @@ local function cut_from_text(pos, input_text, player)
 	letter_cutter.remove_from_input(pos, origname, tostring(math.ceil(totalcost)))
 	playerinv:set_list("main", throwawayinv:get_list("main"))
 
-	minetest.remove_detached_inventory("letter_cutter:throwaway")
+	core.remove_detached_inventory("letter_cutter:throwaway")
 end
 
 -- Implement on_construct.
@@ -266,7 +266,7 @@ end
 --
 -- Initialize a new letter cutter.
 function letter_cutter.on_construct(pos)
-	local meta = minetest.get_meta(pos)
+	local meta = core.get_meta(pos)
 	local groupname = letter_cutter.group_name(pos)
 	update_cutter_formspec(pos)
 
@@ -289,7 +289,7 @@ end
 --
 -- Allow digging if the letter cutter is empty.
 function letter_cutter.can_dig(pos, _player)
-	local meta = minetest.get_meta(pos)
+	local meta = core.get_meta(pos)
 	local inv = meta:get_inventory()
 	if not inv:is_empty("input") then
 		return false
@@ -317,7 +317,7 @@ function letter_cutter.on_receive_fields(pos, _formname, fields, sender)
 	end
 end
 
-minetest.register_node("letters:letter_cutter_lower",  {
+core.register_node("letters:letter_cutter_lower",  {
 	description = "Lower Case Leter Cutter",
 	drawtype = "nodebox",
 	node_box = {
@@ -352,7 +352,7 @@ minetest.register_node("letters:letter_cutter_lower",  {
 	can_dig = letter_cutter.can_dig,
 	-- Set the cutter type and owner.
 	after_place_node = function(pos, placer)
-		local meta = minetest.get_meta(pos)
+		local meta = core.get_meta(pos)
 		local owner = placer and placer:get_player_name() or ""
 		meta:set_string("owner",  owner)
 		meta:set_string("infotext",
@@ -366,7 +366,7 @@ minetest.register_node("letters:letter_cutter_lower",  {
 	on_receive_fields = letter_cutter.on_receive_fields,
 })
 
-minetest.register_craft({
+core.register_craft({
 	output = "letters:letter_cutter_lower",
 	recipe = {
 		{"default:tree", "default:tree", "default:tree"},
@@ -375,7 +375,7 @@ minetest.register_craft({
 	},
 })
 
-minetest.register_node("letters:letter_cutter_upper",  {
+core.register_node("letters:letter_cutter_upper",  {
 	description = "Upper Case Leter Cutter",
 	drawtype = "nodebox",
 	node_box = {
@@ -407,7 +407,7 @@ minetest.register_node("letters:letter_cutter_upper",  {
 	can_dig = letter_cutter.can_dig,
 	-- Set the cutter type and owner.
 	after_place_node = function(pos, placer)
-		local meta = minetest.get_meta(pos)
+		local meta = core.get_meta(pos)
 		local owner = placer and placer:get_player_name() or ""
 		meta:set_string("owner",  owner)
 		meta:set_string("infotext",
@@ -421,7 +421,7 @@ minetest.register_node("letters:letter_cutter_upper",  {
 	on_receive_fields = letter_cutter.on_receive_fields,
 })
 
-minetest.register_craft({
+core.register_craft({
 	output = "letters:letter_cutter_upper",
 	recipe = {
 		{"default:tree", "default:tree", "default:tree"},
@@ -430,7 +430,7 @@ minetest.register_craft({
 	},
 })
 
-minetest.register_node("letters:letter_cutter_digit",  {
+core.register_node("letters:letter_cutter_digit",  {
 	description = "Digit Cutter",
 	drawtype = "nodebox",
 	node_box = {
@@ -464,7 +464,7 @@ minetest.register_node("letters:letter_cutter_digit",  {
 	can_dig = letter_cutter.can_dig,
 	-- Set the cutter type and owner.
 	after_place_node = function(pos, placer)
-		local meta = minetest.get_meta(pos)
+		local meta = core.get_meta(pos)
 		local owner = placer and placer:get_player_name() or ""
 		meta:set_string("owner",  owner)
 		meta:set_string("infotext",
@@ -478,7 +478,7 @@ minetest.register_node("letters:letter_cutter_digit",  {
 	on_receive_fields = letter_cutter.on_receive_fields,
 })
 
-minetest.register_craft({
+core.register_craft({
 	output = "letters:letter_cutter_digit",
 	recipe = {
 		{"default:tree", "default:tree", "default:tree"},

--- a/mod.conf
+++ b/mod.conf
@@ -1,2 +1,3 @@
 name = letters
+description = Adds a letter cutting tool with letter "signlike" nodes.
 optional_depends = darkage, colouredstonebricks, default

--- a/registrations.lua
+++ b/registrations.lua
@@ -1,5 +1,5 @@
 
-if minetest.get_modpath("default") then
+if core.get_modpath("default") then
 	local default_nodes = {
 		{"stone", "stone"},
 		{"cobble", "cobble",},
@@ -28,13 +28,13 @@ if minetest.get_modpath("default") then
 
 	for _, row in pairs(default_nodes) do
 		local nodename = "default:" ..row[1]
-		local ndef = minetest.registered_nodes[nodename]
+		local ndef = core.registered_nodes[nodename]
 		local texture = "default_" ..row[2].. ".png"
 		letters.register_letters("default", row[1], nodename, ndef.description, texture)
 	end
 end
 
-if minetest.get_modpath("darkage") then
+if core.get_modpath("darkage") then
 	letters.register_letters("darkage", "marble", "darkage:marble", "Marble", "darkage_marble.png")
 	letters.register_letters("darkage", "basalt", "darkage:basalt", "Basalt", "darkage_basalt.png")
 	letters.register_letters("darkage", "serpentine", "darkage:serpentine", "Serpentine", "darkage_serpentine.png")
@@ -54,7 +54,7 @@ if minetest.get_modpath("darkage") then
 	letters.register_letters("darkage", "slate_tile", "darkage:slate_tile", "Slate Tile", "darkage_slate_tile.png")
 end
 
-if minetest.get_modpath("colouredstonebricks") then
+if core.get_modpath("colouredstonebricks") then
 	letters.register_letters("colouredstonebricks", "black", "colouredstonebricks:black", "Black", "colouredstonebricks_black.png")
 	letters.register_letters("colouredstonebricks", "cyan", "colouredstonebricks:cyan", "Cyan", "colouredstonebricks_cyan.png")
 	letters.register_letters("colouredstonebricks", "brown", "colouredstonebricks:brown", "Brown", "colouredstonebricks_brown.png")


### PR DESCRIPTION
The letter cutter UI relied on minetest.get_dir_list() to enumerate texture files.
Since directory listings are not guaranteed to be ordered, the resulting letter
slots could appear in a non-alphabetical order.

This PR sorts the texture list before processing, ensuring deterministic and
alphabetical ordering.

Also migrates uses of the legacy `minetest` namespace to `core`.